### PR TITLE
Feature - Add tests

### DIFF
--- a/models/theme_parks_models.yml
+++ b/models/theme_parks_models.yml
@@ -3,13 +3,63 @@ version: 2
 models:
   - name: dim_park
     description: Table of parks from destinations.
+    columns:
+      - name: id
+        tests:
+          - not_null
+          - unique
+      - name: name
+        tests:
+          - not_null
+      - name: destination_id
+        tests:
+          - not_null
   - name: dim_park_children
     description: Table of children entities of parks.
+    columns:
+      - name: park_id
+        tests:
+          - not_null
+      - name: park_name
+        tests:
+          - not_null
+      - name: child_id
+        tests:
+          - not_null
+          - unique
+      - name: child_name
+        tests:
+          - not_null
   - name: dim_destination
     description: Table of destinations.
+    columns:
+      - name: id
+        tests:
+          - not_null
+          - unique
+      - name: name
+        tests:
+          - not_null
   - name: fact_recent_live_data
     description: Table of the most recently synced live data that has been unpacked.
+    columns:
+      - name: attraction_id
+        tests:
+          - not_null
+      - name: attraction_name
+        tests:
+          - not_null
+      - name: park_id
+        tests:
+          - not_null
 
 snapshots:
   - name: live_data_snapshot
     description: Snapshot for tracking changes in live data.
+    columns:
+      - name: id
+        tests:
+          - not_null
+      - name: livedata
+        tests:
+          - not_null

--- a/tests/assert_total_rows_in_fact_recent_live_data_equals_all_current_livedata_entries_from_snapshot.sql
+++ b/tests/assert_total_rows_in_fact_recent_live_data_equals_all_current_livedata_entries_from_snapshot.sql
@@ -1,0 +1,12 @@
+-- assert that the number of nows in fact_recent_live_data equals the count of entries in the livedata arrays
+-- of all current live data from live_data_snapshot
+
+SELECT
+    COUNT(unpacked_live_data)
+FROM {{ ref('live_data_snapshot') }} lds, JSONB_ARRAY_ELEMENTS(lds.livedata) AS unpacked_live_data
+WHERE dbt_updated_at IS NULL
+HAVING COUNT(unpacked_live_data) != (
+    SELECT
+        COUNT(*)
+    FROM {{ ref('fact_recent_live_data') }}
+)


### PR DESCRIPTION
closes #5 

- Added `not_null` and `unique` tests to applicable columns across all models.
- Added test asserting that livedata is unpacked correctly from the `live_data_snapshot` into `fact_recent_live_data`