### PR TITLE
Fix - Fixed test filtering by incorrect dbt column

### DIFF
--- a/tests/assert_total_rows_in_fact_recent_live_data_equals_all_current_livedata_entries_from_snapshot.sql
+++ b/tests/assert_total_rows_in_fact_recent_live_data_equals_all_current_livedata_entries_from_snapshot.sql
@@ -4,7 +4,7 @@
 SELECT
     COUNT(unpacked_live_data)
 FROM {{ ref('live_data_snapshot') }} lds, JSONB_ARRAY_ELEMENTS(lds.livedata) AS unpacked_live_data
-WHERE dbt_updated_at IS NULL
+WHERE dbt_valid_to IS NULL
 HAVING COUNT(unpacked_live_data) != (
     SELECT
         COUNT(*)


### PR DESCRIPTION
`assert_total_rows_in_fact_recent_live_data_equals_all_current_livedata_entries_from_snapshot` should be filtering by `dbt_valid_to` not `dbt_updated_at`